### PR TITLE
fix(release-rust): skip crates already published at the tag version

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -81,6 +81,14 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           for CRATE in ${{ inputs.crates }}; do
+            # Skip if this exact version is already indexed on crates.io
+            if curl -sf "https://crates.io/api/v1/crates/${CRATE}/${VERSION}" \
+                 -H "User-Agent: brefwiz-ci/1.0" \
+               | grep -q '"num"'; then
+              echo "==> Skipping ${CRATE} ${VERSION} (already on crates.io)"
+              continue
+            fi
+
             echo "==> Publishing ${CRATE} ${VERSION}"
             cargo publish -p "${CRATE}"
 


### PR DESCRIPTION
## Summary

- Before publishing each crate, check the crates.io API for the target version
- Skip with a clear log message if already indexed instead of failing
- Unblocks workspace releases where only a subset of crates changed

## Why

When a Rust workspace has multiple publishable crates and only some of
them change between releases, `cargo publish` exits 101 on any crate
whose version already exists. This made the entire publish job fail.

## Test plan

- [ ] Trigger a release where one workspace crate is unchanged — pipeline skips it cleanly
- [ ] Trigger a release where all crates are new — all publish normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)