### PR TITLE
Add policy validator to shared Rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,6 +99,13 @@ jobs:
               .shared-ci-workflows/policies/audit.toml
               .shared-ci-workflows/policies/deny.toml
 
+      - name: Validate central policy mapping
+        if: inputs.use-central-policies
+        run: cargo-vuln-policy-validator
+             .shared-ci-workflows/policies/audit.toml
+             .shared-ci-workflows/policies/deny.toml
+             .shared-ci-workflows/policies/exceptions.yaml
+
       - name: cargo audit (central)
         if: inputs.use-central-policies
         run: cargo audit --file .shared-ci-workflows/policies/audit.toml

--- a/README.md
+++ b/README.md
@@ -48,15 +48,18 @@ touches a Dockerfile:
 | Image | Based on | Contents |
 |---|---|---|
 | `ghcr.io/brefwiz/ci-base:latest` | `debian:trixie-slim` | Node, Java, openapi-generator, kubectl, helm, helmfile, k3d, nats, Docker CLI, Zig |
-| `ghcr.io/brefwiz/ci:latest` | `ci-base` | + Rust stable, cargo-nextest, llvm-cov, cargo-audit, cargo-deny, cargo-hack, cargo-chef, sqlx-cli, sccache, cargo-zigbuild |
+| `ghcr.io/brefwiz/ci:latest` | `ci-base` | + Rust stable, cargo-nextest, llvm-cov, cargo-audit, cargo-deny, cargo-hack, cargo-chef, sqlx-cli, sccache, cargo-zigbuild, cargo-vuln-policy-validator |
 
 Tags: `latest` (main branch) and `sha-<short>` (per-commit).
 
 ## Central security policies
 
-`policies/deny.toml` and `policies/audit.toml` are the central cargo-deny and
-cargo-audit configs. Every advisory allowlist entry carries a `# review-by: YYYY-MM-DD`
-comment; `scripts/check-policy-expiry.sh` fails CI once the date passes.
+`policies/deny.toml`, `policies/audit.toml`, and `policies/exceptions.yaml`
+form the central cargo-deny / cargo-audit / exception-review contract. Every
+advisory allowlist entry carries a `# review-by: YYYY-MM-DD` comment;
+`scripts/check-policy-expiry.sh` fails CI once the date passes, and
+`cargo-vuln-policy-validator` checks that the TOML ignore lists match the YAML
+exceptions file.
 
 See [`policies/README.md`](policies/README.md) for the full review contract.
 

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -10,6 +10,7 @@
 #   - Fast linker: mold + clang (already in base, wired up here)
 #   - cargo-nextest, cargo-llvm-cov, cargo-audit, cargo-deny, cargo-hack, sqlx-cli
 #   - cargo-zigbuild (uses Zig from ci-base for reliable aarch64-musl cross-compilation)
+#   - cargo-vuln-policy-validator (central allowlist/policy validation helper)
 
 ARG RUST_VERSION=1.94
 ARG CARGO_NEXTEST_VERSION=0.9.114
@@ -20,6 +21,8 @@ ARG CARGO_DENY_VERSION=0.19.4
 ARG CARGO_HACK_VERSION=0.6.37
 ARG SCCACHE_VERSION=0.10.0
 ARG CARGO_ZIGBUILD_VERSION=0.19.4
+ARG CARGO_VULN_POLICY_VALIDATOR_REPO=https://github.com/brefwiz/cargo-vuln-policy-validator
+ARG CARGO_VULN_POLICY_VALIDATOR_REF=main
 ARG CI_BASE_TAG=latest
 
 FROM ghcr.io/brefwiz/ci-base:${CI_BASE_TAG}
@@ -33,6 +36,8 @@ ARG CARGO_DENY_VERSION
 ARG CARGO_HACK_VERSION
 ARG SCCACHE_VERSION
 ARG CARGO_ZIGBUILD_VERSION
+ARG CARGO_VULN_POLICY_VALIDATOR_REPO
+ARG CARGO_VULN_POLICY_VALIDATOR_REF
 
 # ── Rust toolchain ─────────────────────────────────────────────────────────────
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -58,6 +63,10 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
     && cargo install cargo-hack --version ${CARGO_HACK_VERSION} --locked \
     && cargo install cargo-audit --locked \
     && cargo install cargo-deny --version ${CARGO_DENY_VERSION} --locked \
+    && cargo install cargo-vuln-policy-validator \
+        --git ${CARGO_VULN_POLICY_VALIDATOR_REPO} \
+        --branch ${CARGO_VULN_POLICY_VALIDATOR_REF} \
+        --locked \
     && cargo install sqlx-cli \
         --version ${SQLX_CLI_VERSION} \
         --no-default-features \
@@ -72,6 +81,7 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
     && cargo hack --version \
     && cargo audit --version \
     && cargo deny --version \
+    && cargo-vuln-policy-validator --help > /dev/null \
     && sqlx --version \
     && sccache --version \
     && cargo zigbuild --help > /dev/null
@@ -96,5 +106,5 @@ RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup
 
 # ── Labels ────────────────────────────────────────────────────────────────────
 LABEL org.opencontainers.image.title="ci" \
-      org.opencontainers.image.description="Full CI image — ci-base + Rust toolchain + cargo tools" \
+      org.opencontainers.image.description="Full CI image — ci-base + Rust toolchain + cargo tools + policy validator" \
       org.opencontainers.image.source="https://github.com/brefwiz/shared-ci-workflows"

--- a/scripts/check-policy-expiry.sh
+++ b/scripts/check-policy-expiry.sh
@@ -5,7 +5,7 @@
 # expiry field, so we enforce it here. Every ignored RUSTSEC id in either file
 # must be preceded by `# review-by: YYYY-MM-DD` (within 3 lines above). CI
 # fails when any is past due; entries within 30 days of expiry warn (nonfatal).
-
+#!/usr/bin/env bash
 set -euo pipefail
 
 AUDIT="${1:-policies/audit.toml}"
@@ -21,102 +21,96 @@ today_epoch=$(date -u -d "$TODAY" +%s 2>/dev/null || date -u -j -f %Y-%m-%d "$TO
 FAIL=0
 WARN=0
 
-# Extract "STATUS<TAB>ID<TAB>REVIEW_DATE" lines from audit.toml via awk.
-ENTRIES=$(awk '
-  /# *review-by: *[0-9]{4}-[0-9]{2}-[0-9]{2}/ {
-    match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/);
-    last_review = substr($0, RSTART, RLENGTH); last_line = NR;
-  }
-  /"RUSTSEC-[0-9]{4}-[0-9]+"/ {
-    match($0, /RUSTSEC-[0-9]{4}-[0-9]+/);
-    id = substr($0, RSTART, RLENGTH);
-    if (last_review == "" || NR - last_line > 3) {
-      print "MISSING\t" id "\t";
-    } else {
-      print "OK\t" id "\t" last_review;
+check_entries() {
+  local file="$1"
+  local mode="$2"
+
+  awk '
+    function reset_meta() {
+      review=""; reason=""; risk=""; impact=""; tracking=""; owner="";
+      last_line=0;
     }
-  }
-' "$AUDIT")
+
+    BEGIN { reset_meta() }
+
+    {
+      if ($0 ~ /# *review-by: *[0-9]{4}-[0-9]{2}-[0-9]{2}/) {
+        match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/);
+        review = substr($0, RSTART, RLENGTH); last_line = NR;
+      }
+      if ($0 ~ /# *reason:/)   { reason=1; last_line=NR }
+      if ($0 ~ /# *risk:/)     { risk=1; last_line=NR }
+      if ($0 ~ /# *impact:/)   { impact=1; last_line=NR }
+      if ($0 ~ /# *tracking:/) { tracking=1; last_line=NR }
+      if ($0 ~ /# *owner:/)    { owner=1; last_line=NR }
+
+      if ($0 ~ /RUSTSEC-[0-9]{4}-[0-9]+/) {
+        match($0, /RUSTSEC-[0-9]{4}-[0-9]+/);
+        id = substr($0, RSTART, RLENGTH);
+
+        missing=""
+        if (review == "" || NR - last_line > 5) missing = missing " review-by"
+        if (!reason)   missing = missing " reason"
+        if (!risk)     missing = missing " risk"
+        if (!impact)   missing = missing " impact"
+        if (!tracking) missing = missing " tracking"
+        if (!owner)    missing = missing " owner"
+
+        if (missing != "") {
+          print "MISSING\t" id "\t" review "\t" missing
+        } else {
+          print "OK\t" id "\t" review "\t"
+        }
+
+        reset_meta()
+      }
+    }
+  ' "$file"
+}
+
+process_results() {
+  local entries="$1"
+
+  while IFS=$'\t' read -r status id review missing; do
+    [[ -z "$status" ]] && continue
+
+    case "$status" in
+      MISSING)
+        echo "  ✗ $id — missing fields:$missing"
+        FAIL=1
+        ;;
+      OK)
+        rev_epoch=$(date -u -d "$review" +%s 2>/dev/null || date -u -j -f %Y-%m-%d "$review" +%s)
+        delta=$(( rev_epoch - today_epoch ))
+
+        if (( delta < 0 )); then
+          echo "  ✗ $id — review-by $review is PAST DUE"
+          FAIL=1
+        elif (( delta < WARN_SEC )); then
+          days=$(( delta / 86400 ))
+          echo "  ⚠ $id — review-by $review (expires in ${days}d)"
+          WARN=1
+        else
+          echo "  ✓ $id — review-by $review"
+        fi
+        ;;
+    esac
+  done < <(printf '%s\n' "$entries")
+}
 
 echo "==> Checking $AUDIT..."
-if [[ -z "$ENTRIES" ]]; then
-  echo "  (no RUSTSEC ignore entries)"
-fi
-while IFS=$'\t' read -r status id review; do
-  [[ -z "$status" ]] && continue
-  case "$status" in
-    MISSING)
-      echo "  ✗ $id — no '# review-by: YYYY-MM-DD' within 3 lines above"
-      FAIL=1
-      ;;
-    OK)
-      rev_epoch=$(date -u -d "$review" +%s 2>/dev/null || date -u -j -f %Y-%m-%d "$review" +%s)
-      delta=$(( rev_epoch - today_epoch ))
-      if (( delta < 0 )); then
-        echo "  ✗ $id — review-by $review is PAST DUE (re-review, bump +90d, or remove)"
-        FAIL=1
-      elif (( delta < WARN_SEC )); then
-        days=$(( delta / 86400 ))
-        echo "  ⚠ $id — review-by $review (expires in ${days}d)"
-        WARN=1
-      else
-        echo "  ✓ $id — review-by $review"
-      fi
-      ;;
-  esac
-done < <(printf '%s\n' "$ENTRIES")
+AUDIT_ENTRIES=$(check_entries "$AUDIT" "audit")
+[[ -z "$AUDIT_ENTRIES" ]] && echo "  (no RUSTSEC ignore entries)"
+process_results "$AUDIT_ENTRIES"
 
-# deny.toml: same contract as audit.toml — every [advisories.ignore] entry
-# must be preceded by `# review-by: YYYY-MM-DD` within 3 lines.
 echo "==> Checking $DENY..."
-DENY_ENTRIES=$(awk '
-  /^\[advisories\]/ {in_adv=1; next}
-  /^\[/ && !/advisories/ {in_adv=0}
-  /# *review-by: *[0-9]{4}-[0-9]{2}-[0-9]{2}/ {
-    match($0, /[0-9]{4}-[0-9]{2}-[0-9]{2}/);
-    last_review = substr($0, RSTART, RLENGTH); last_line = NR;
-  }
-  in_adv && /id *= *"RUSTSEC-/ {
-    match($0, /RUSTSEC-[0-9]{4}-[0-9]+/);
-    id = substr($0, RSTART, RLENGTH);
-    if (last_review == "" || NR - last_line > 3) {
-      print "MISSING\t" id "\t";
-    } else {
-      print "OK\t" id "\t" last_review;
-    }
-  }
-' "$DENY")
-
-if [[ -z "$DENY_ENTRIES" ]]; then
-  echo "  (no RUSTSEC ignore entries)"
-fi
-while IFS=$'\t' read -r status id review; do
-  [[ -z "$status" ]] && continue
-  case "$status" in
-    MISSING)
-      echo "  ✗ $id — no '# review-by: YYYY-MM-DD' within 3 lines above"
-      FAIL=1
-      ;;
-    OK)
-      rev_epoch=$(date -u -d "$review" +%s 2>/dev/null || date -u -j -f %Y-%m-%d "$review" +%s)
-      delta=$(( rev_epoch - today_epoch ))
-      if (( delta < 0 )); then
-        echo "  ✗ $id — review-by $review is PAST DUE (re-review, bump +90d, or remove)"
-        FAIL=1
-      elif (( delta < WARN_SEC )); then
-        days=$(( delta / 86400 ))
-        echo "  ⚠ $id — review-by $review (expires in ${days}d)"
-        WARN=1
-      else
-        echo "  ✓ $id — review-by $review"
-      fi
-      ;;
-  esac
-done < <(printf '%s\n' "$DENY_ENTRIES")
+DENY_ENTRIES=$(check_entries "$DENY" "deny")
+[[ -z "$DENY_ENTRIES" ]] && echo "  (no RUSTSEC ignore entries)"
+process_results "$DENY_ENTRIES"
 
 if [[ "$FAIL" != "0" ]]; then
   echo ""
-  echo "FAIL: policy review contract violated. See policies/README.md."
+  echo "FAIL: policy review contract violated."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- install `cargo-vuln-policy-validator` in the shared `ci` image
- run the validator in `Security (audit + deny)` before `cargo audit` and `cargo deny` when central policies are enabled
- document `exceptions.yaml` and the validator as part of the shared policy contract

## Test plan

- [x] reviewed Dockerfile install path and PATH exposure in the `ci` image
- [x] reviewed reusable Rust workflow wiring for the central security policy path
- [ ] build and publish the updated `ghcr.io/brefwiz/ci` image
