### PR TITLE
fix(docker): smoke-test validator with valid policy files

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -81,7 +81,11 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
     && cargo hack --version \
     && cargo audit --version \
     && cargo deny --version \
-    && cargo-vuln-policy-validator --help > /dev/null \
+    && printf '[advisories]\nignore = ["RUSTSEC-0000-0000"]\n' > /tmp/smoke-audit.toml \
+    && printf '[advisories]\nignore = []\n' > /tmp/smoke-deny.toml \
+    && printf 'exceptions:\n  - id: RUSTSEC-0000-0000\n    owner: smoke-test\n    review_by: 2099-01-01\n    reason: smoke test\n    risk: known\n    impact: low\n    tracking: NONE\n    resolution: none\n' > /tmp/smoke-exceptions.yaml \
+    && cargo-vuln-policy-validator /tmp/smoke-audit.toml /tmp/smoke-deny.toml /tmp/smoke-exceptions.yaml \
+    && rm /tmp/smoke-audit.toml /tmp/smoke-deny.toml /tmp/smoke-exceptions.yaml \
     && sqlx --version \
     && sccache --version \
     && cargo zigbuild --help > /dev/null


### PR DESCRIPTION
## Summary

- `cargo-vuln-policy-validator` exits 2 on wrong arg count (including `--help`), so the previous smoke test always failed during image build
- Replace with a proper invocation using minimal valid temp policy files that produce a clean exit 0
- Unblocks reverting the disabled `Validate central policy mapping` step in `rust.yml`

## Test plan

- [ ] Image build workflow succeeds with the new smoke test
- [ ] Re-enable the commented-out step in `rust.yml` once image is rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)