### PR TITLE
ci(rust.yml): re-enable policy-validator step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,13 +98,12 @@ jobs:
             policies
             scripts
 
-      # TODO: re-enable once ghcr.io/brefwiz/ci image is rebuilt with cargo-vuln-policy-validator
-      # - name: Validate central policy mapping
-      #   if: inputs.use-central-policies
-      #   run: cargo-vuln-policy-validator
-      #          .shared-ci-workflows/policies/audit.toml
-      #          .shared-ci-workflows/policies/deny.toml
-      #          .shared-ci-workflows/policies/exceptions.yaml
+      - name: Validate central policy mapping
+        if: inputs.use-central-policies
+        run: cargo-vuln-policy-validator
+               .shared-ci-workflows/policies/audit.toml
+               .shared-ci-workflows/policies/deny.toml
+               .shared-ci-workflows/policies/exceptions.yaml
 
       - name: cargo audit (central)
         if: inputs.use-central-policies


### PR DESCRIPTION
## Summary

- Re-enables the `Validate central policy mapping` step that was disabled in #3 while the CI image was missing `cargo-vuln-policy-validator`
- Image is now rebuilt (PR #5) with the tool installed and smoke-tested

## Test plan

- [ ] Rust CI workflow runs with `use-central-policies: true` and the validator step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)