### PR TITLE
fix(rust.yml): enable security job (was if: false)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
   security:
     name: Security (audit + deny)
     runs-on: ubuntu-latest
-    if: false
+    if: inputs.run-security
     container: ${{ inputs.container-image }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Security job had `if: false` hardcoded, causing it to always be skipped regardless of the `run-security` input
- Replace with `if: inputs.run-security` so the default (`true`) actually runs audit + deny

## Test plan

- [ ] Security job runs on next PR in a consuming repo (e.g. socle)
- [ ] `cargo-vuln-policy-validator` step executes with central policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)