### PR TITLE
fix(policies): add missing exceptions.yaml

### DIFF
--- a/policies/exceptions.yaml
+++ b/policies/exceptions.yaml
@@ -1,0 +1,1 @@
+exceptions: []


### PR DESCRIPTION
## Summary

- `cargo-vuln-policy-validator` requires three files: `audit.toml`, `deny.toml`, and `exceptions.yaml`
- `exceptions.yaml` was never added to `policies/`, causing the validator to fail with "No such file or directory"
- Adds an empty exceptions list to unblock the security job

## Test plan

- [ ] Security job passes on next socle CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)