### PR TITLE
fix(policies): populate exceptions.yaml with audit ignores

### DIFF
--- a/policies/exceptions.yaml
+++ b/policies/exceptions.yaml
@@ -1,1 +1,36 @@
-exceptions: []
+exceptions:
+  - id: RUSTSEC-2026-0098
+    owner: team-security
+    review_by: 2026-07-15
+    reason: "rustls-webpki 0.101.7 via rustls 0.21 → aws-smithy-http-client 1.1.12; TLS cert name-constraint edge cases not triggered by AWS service endpoint calls"
+    risk: known
+    impact: low
+    tracking: NONE
+    resolution: remove once aws-smithy-http-client migrates to rustls 0.22+
+
+  - id: RUSTSEC-2026-0099
+    owner: team-security
+    review_by: 2026-07-15
+    reason: "rustls-webpki 0.101.7 via rustls 0.21 → aws-smithy-http-client 1.1.12; TLS cert name-constraint edge cases not triggered by AWS service endpoint calls"
+    risk: known
+    impact: low
+    tracking: NONE
+    resolution: remove once aws-smithy-http-client migrates to rustls 0.22+
+
+  - id: RUSTSEC-2023-0071
+    owner: team-security
+    review_by: 2026-07-15
+    reason: "rsa Marvin Attack timing side-channel via sqlx 0.8 lockfile; only postgres feature used at runtime, MySQL + RSA code never linked"
+    risk: known
+    impact: low
+    tracking: NONE
+    resolution: remove once sqlx ships a patched version
+
+  - id: RUSTSEC-2026-0097
+    owner: team-security
+    review_by: 2026-07-20
+    reason: "rand UB when custom logger calls rand::rng() during ThreadRng reseed; via sqlx-postgres 0.8 → rand 0.8; UB conditions not met (no custom logger + trace logging + reseed path)"
+    risk: known
+    impact: low
+    tracking: NONE
+    resolution: remove once sqlx upgrades to rand 0.9


### PR DESCRIPTION
## Summary

- `exceptions.yaml` was added empty, causing `cargo-vuln-policy-validator` to fail with "policy validation failed"
- The validator requires every `audit.toml` ignore to have a matching exception entry
- Adds the 4 current exceptions (RUSTSEC-2026-0097/0098/0099, RUSTSEC-2023-0071) with owner, reason, and review dates matching the existing policy comments
- Validated locally with exit 0

## Test plan

- [ ] Security job passes on next socle CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)