### PR TITLE
feat(ci): install api-bones-sdk-gen in CI image

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,98 @@
+name: Release npm package(s) (reusable)
+
+# Publishes one or more npm packages to GitHub Packages and optionally
+# mirrors to npmjs.com.  Called by downstream repos on tag push.
+#
+# Usage:
+#
+#   on:
+#     push:
+#       tags: ['v*']
+#
+#   jobs:
+#     publish-npm:
+#       uses: brefwiz/shared-ci-workflows/.github/workflows/release-npm.yml@main
+#       with:
+#         packages: "api-bones-axios"
+#       permissions:
+#         contents: read
+#         packages: write
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: >
+          Space-separated list of package directory names (relative to repo
+          root) to publish.  Example: "api-bones-axios"
+        type: string
+        required: true
+      node-version:
+        description: Node.js version to use
+        type: string
+        default: "22"
+      mirror-npmjs:
+        description: >
+          Also publish to npmjs.com.  Requires the npm-token secret.
+        type: boolean
+        default: false
+    secrets:
+      npm-token:
+        description: npmjs.com token (required only when mirror-npmjs is true)
+        required: false
+
+jobs:
+  publish-npm:
+    name: Publish npm package(s)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: https://npm.pkg.github.com
+          scope: "@brefwiz"
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for PKG_DIR in ${{ inputs.packages }}; do
+            echo "==> Building and publishing ${PKG_DIR}"
+            cd "${PKG_DIR}"
+            npm ci
+            npm run build
+            # Ensure publishConfig points to GitHub Packages
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+              pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            npm publish --access public
+            cd ..
+          done
+
+      - name: Mirror to npmjs.com
+        if: ${{ inputs.mirror-npmjs }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+        run: |
+          # Switch auth to npmjs.com for the mirror publish
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          for PKG_DIR in ${{ inputs.packages }}; do
+            echo "==> Mirroring ${PKG_DIR} to npmjs.com"
+            cd "${PKG_DIR}"
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+              pkg.publishConfig = { registry: 'https://registry.npmjs.org' };
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            npm publish --access public
+            cd ..
+          done

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -13,6 +13,7 @@
 #   - cargo-vuln-policy-validator (central allowlist/policy validation helper)
 
 ARG RUST_VERSION=1.94
+ARG API_BONES_SDK_GEN_VERSION=0.1.0
 ARG CARGO_NEXTEST_VERSION=0.9.114
 ARG CARGO_LLVM_COV_VERSION=0.8.4
 ARG CARGO_CHEF_VERSION=0.1.77
@@ -38,6 +39,7 @@ ARG SCCACHE_VERSION
 ARG CARGO_ZIGBUILD_VERSION
 ARG CARGO_VULN_POLICY_VALIDATOR_REPO
 ARG CARGO_VULN_POLICY_VALIDATOR_REF
+ARG API_BONES_SDK_GEN_VERSION
 
 # ── Rust toolchain ─────────────────────────────────────────────────────────────
 ENV RUSTUP_HOME=/usr/local/rustup \
@@ -74,6 +76,12 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
         --locked \
     && cargo install sccache --version ${SCCACHE_VERSION} --locked \
     && cargo install cargo-zigbuild --version ${CARGO_ZIGBUILD_VERSION} --locked \
+    && cargo install api-bones-sdk-gen \
+        --version ${API_BONES_SDK_GEN_VERSION} \
+        --registry brefwiz \
+        --locked \
+    && mkdir -p /opt/brefwiz \
+    && api-bones-sdk-gen makefile > /opt/brefwiz/api-bones-sdk.mk \
     && rm -rf ${CARGO_HOME}/registry/cache \
     && cargo nextest --version \
     && cargo llvm-cov --version \
@@ -88,7 +96,8 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
     && rm /tmp/smoke-audit.toml /tmp/smoke-deny.toml /tmp/smoke-exceptions.yaml \
     && sqlx --version \
     && sccache --version \
-    && cargo zigbuild --help > /dev/null
+    && cargo zigbuild --help > /dev/null \
+    && api-bones-sdk-gen --version
 
 # ── CI-optimised Rust defaults ────────────────────────────────────────────────
 # sccache: RUSTC_WRAPPER is NOT set globally — jobs opt in by setting it to


### PR DESCRIPTION
## Summary

- Install `api-bones-sdk-gen` (from brefwiz cargo registry) as a static binary in the CI image
- Drop `api-bones-sdk.mk` to `/opt/brefwiz/` so services can `include /opt/brefwiz/api-bones-sdk.mk` in their Makefile

Product teams set `SERVER_OPENAPI_BIN`, `SDK_RUST_CRATE`, `SDK_TS_PKG` and get correct Rust + TypeScript SDKs with `ApiResponse` envelope handling by default — no per-service `build.rs` or TS overlay wiring required.

Depends on brefwiz/api-bones#24 being merged and `api-bones-sdk-gen 0.1.0` published to the brefwiz registry.

## Test plan

- `api-bones-sdk-gen --version` smoke check added to the existing cargo tools verification block
- `api-bones-sdk-gen makefile` emits `api-bones-sdk.mk` to `/opt/brefwiz/` at image build time
- Follow-up: itinerwiz migration PR adopts `include /opt/brefwiz/api-bones-sdk.mk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)