### PR TITLE
feat(ci): install api-bones-sdk-gen from crates.io

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -78,7 +78,6 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
     && cargo install cargo-zigbuild --version ${CARGO_ZIGBUILD_VERSION} --locked \
     && cargo install api-bones-sdk-gen \
         --version ${API_BONES_SDK_GEN_VERSION} \
-        --registry brefwiz \
         --locked \
     && mkdir -p /opt/brefwiz \
     && api-bones-sdk-gen makefile > /opt/brefwiz/api-bones-sdk.mk \


### PR DESCRIPTION
## Summary

- Installs `api-bones-sdk-gen` binary in the CI image and drops `api-bones-sdk.mk` to `/opt/brefwiz/`
- Adds `release-npm` reusable workflow for publishing packages to GitHub Packages
- Fixes image build failure: `--registry brefwiz` referenced a private Cargo registry unavailable in a public image build; `api-bones-sdk-gen` is published on crates.io so no registry flag is needed

## Test plan

- [ ] CI image builds successfully without a private Cargo registry configured
- [ ] `api-bones-sdk-gen --version` runs in the built image
- [ ] `/opt/brefwiz/api-bones-sdk.mk` is present in the image
- [ ] `release-npm` workflow is callable from product repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)