### PR TITLE
feat(ci): install api-bones-sdk-gen + fix aarch64 zigbuild linker conflict

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -105,7 +105,6 @@ RUN cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked \
 ENV CARGO_TERM_COLOR=always \
     CARGO_INCREMENTAL=0 \
     CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
     RUSTFLAGS="-C link-arg=-fuse-ld=mold" \
     RUST_BACKTRACE=1 \
     SQLX_OFFLINE=true \


### PR DESCRIPTION
## Summary

- Installs \`api-bones-sdk-gen\` in the CI image (from crates.io), baking \`/opt/brefwiz/api-bones-sdk.mk\` into the image at build time
- Removes the stale \`CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc\` env var from \`ci.Dockerfile\` — this conflicted with \`cargo zigbuild\` (which manages its own linker via Zig) causing \`linker 'aarch64-linux-musl-gcc' not found\` on services that cross-compile for aarch64-unknown-linux-musl
- Adds a reusable \`release-npm.yml\` workflow for GitHub Packages npm publishing

## Test plan

- [ ] CI image builds successfully with new ARGs
- [ ] \`cargo zigbuild --target aarch64-unknown-linux-musl\` works in the new image (no linker error)
- [ ] \`api-bones-sdk-gen --version\` is present in the image
- [ ] \`/opt/brefwiz/api-bones-sdk.mk\` exists in the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)