### PR TITLE
chore(docker): bump Rust toolchain 1.94 → 1.95 in CI image

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -12,7 +12,7 @@
 #   - cargo-zigbuild (uses Zig from ci-base for reliable aarch64-musl cross-compilation)
 #   - cargo-vuln-policy-validator (central allowlist/policy validation helper)
 
-ARG RUST_VERSION=1.94
+ARG RUST_VERSION=1.95
 ARG API_BONES_SDK_GEN_VERSION=0.1.0
 ARG CARGO_NEXTEST_VERSION=0.9.114
 ARG CARGO_LLVM_COV_VERSION=0.8.4


### PR DESCRIPTION
## Summary

- `stable` resolved to 1.95.0 on 2026-04-16; the CI image was built with 1.94 + components (clippy, rustfmt, llvm-tools-preview).
- When rustup auto-updates `stable` inside the container the new 1.95 toolchain slot has no components, producing `error: 'cargo-clippy' is not installed` (same for rustfmt).
- Bumping `RUST_VERSION` to `1.95` rebuilds `ghcr.io/brefwiz/ci:latest` with the correct toolchain pre-installed.

## Test plan

- [ ] Image builds successfully with 1.95
- [ ] `cargo clippy` and `cargo fmt --check` pass in downstream repos (otel-bootstrap PR #4 is the immediate trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)