### PR TITLE
fix(docker): revert Rust toolchain to 1.94.1 to match repos

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -12,7 +12,7 @@
 #   - cargo-zigbuild (uses Zig from ci-base for reliable aarch64-musl cross-compilation)
 #   - cargo-vuln-policy-validator (central allowlist/policy validation helper)
 
-ARG RUST_VERSION=1.95
+ARG RUST_VERSION=1.94.1
 ARG API_BONES_SDK_GEN_VERSION=0.1.0
 ARG CARGO_NEXTEST_VERSION=0.9.114
 ARG CARGO_LLVM_COV_VERSION=0.8.4


### PR DESCRIPTION
## Summary

- Reverts `RUST_VERSION` from `1.95` → `1.94.1` in `ci.Dockerfile`

## Why

PR #13 bumped the image to 1.95 before the service repos were updated. Every repo pins `channel = "1.94"` in `rust-toolchain.toml`. When CI runs inside the 1.95 image, the repo pin overrides `RUSTUP_TOOLCHAIN`, rustup downloads the 1.94 toolchain fresh — and gets only the compiler, not `rustfmt`/`clippy` — breaking `ci-format` and `ci-lint` on every open PR.

## Fix

Revert the image to 1.94.1 so the baked toolchain matches the repo pin. A separate coordinated PR will bump all repos' `rust-toolchain.toml` to 1.95 before attempting the image upgrade again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)