### PR TITLE
fix(docker): pin Rust to 1.94.1 with RUSTUP_TOOLCHAIN

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -110,7 +110,8 @@ ENV CARGO_TERM_COLOR=always \
     SQLX_OFFLINE=true \
     SCCACHE_DIR=/var/cache/sccache \
     SCCACHE_CACHE_SIZE=30G \
-    SCCACHE_IDLE_TIMEOUT=0
+    SCCACHE_IDLE_TIMEOUT=0 \
+    RUSTUP_TOOLCHAIN=1.94.1
 
 # ── Ensure world-writable cargo/rustup (for non-root CI runners) ──────────────
 RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
## Summary

- The CI image was installed with \`stable\` (a rolling channel), so rustup auto-updated to a new build inside the container but without components (rustfmt, clippy) — causing \`error: 'cargo-fmt' is not installed\`.
- Pins \`RUST_VERSION\` to the exact release \`1.94.1\` so there is nothing for rustup to update.
- Adds \`RUSTUP_TOOLCHAIN=1.94.1\` env var so every \`cargo\`/\`rustup\` invocation inside the container is locked to the baked-in toolchain.

## Test plan

- [ ] Image builds with 1.94.1 + rustfmt + clippy pre-installed
- [ ] \`cargo fmt --check\` and \`cargo clippy\` pass in downstream repos without auto-update errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)