### PR TITLE
feat(check-makefile-contract): require ci-changelog target

### DIFF
--- a/scripts/check-makefile-contract.sh
+++ b/scripts/check-makefile-contract.sh
@@ -26,7 +26,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-REQUIRED_TARGETS=(help fmt ci-format ci-lint ci-test ci-coverage pre-commit)
+REQUIRED_TARGETS=(help fmt ci-format ci-lint ci-test ci-coverage ci-changelog pre-commit)
 
 if [[ ! -f "$MAKEFILE" ]]; then
   echo "::error::Makefile contract: $MAKEFILE not found." >&2
@@ -51,7 +51,7 @@ fi
 
 if [[ "$STRICT_PRE_COMMIT" == "true" ]]; then
   PRE_COMMIT_LINE="$(grep -E '^pre-commit:' "$MAKEFILE" | head -1)"
-  for prereq in ci-format ci-lint ci-test; do
+  for prereq in ci-format ci-lint ci-test ci-changelog; do
     if ! echo "$PRE_COMMIT_LINE" | grep -qw "$prereq"; then
       echo "::error::Makefile contract: pre-commit must depend on '$prereq' (found: $PRE_COMMIT_LINE)" >&2
       exit 1


### PR DESCRIPTION
## Summary

Closes the loop on the `ci-changelog` rollout — adds it to `REQUIRED_TARGETS` in the Makefile contract check, and to the strict-pre-commit prerequisites list.

After this PR:

- Every brefwiz code repo MUST declare a `ci-changelog` Makefile target (per amended ADR-0021).
- The `pre-commit` chain MUST include `ci-changelog` after `ci-format ci-lint ci-test`.
- Repos that don't comply fail CI in the lint stage with a clear pointer.

## Why now

The ci-changelog target was rolled out across all consumer repos in the previous sweep (16 repos). Now that every repo declares the target, the contract check can require it without breaking anyone.

## Test plan

- [x] Local: contract check passes against `socle` (which has the target after the prior sweep merge)
- [x] Local: contract check fails with a clear error against a synthetic Makefile missing `ci-changelog`
- [ ] CI: this repo's own pipeline passes
- [ ] CI: downstream consumer repos still pass
