### PR TITLE
feat(ci-base): install protoc-gen-connect-openapi for OpenAPI codegen

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -29,6 +29,7 @@ ARG HELM_VERSION=4.1.3
 ARG HELMFILE_VERSION=1.4.2
 ARG NATS_VERSION=2.12.5
 ARG BUF_VERSION=1.47.2
+ARG PROTOC_GEN_CONNECT_OPENAPI_VERSION=v0.16.0
 
 FROM debian:trixie-slim
 
@@ -40,6 +41,7 @@ ARG HELM_VERSION
 ARG HELMFILE_VERSION
 ARG NATS_VERSION
 ARG BUF_VERSION
+ARG PROTOC_GEN_CONNECT_OPENAPI_VERSION
 
 # ── System packages ────────────────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -165,6 +167,16 @@ RUN UNAME_M=$(uname -m) \
         -o /usr/local/bin/buf \
     && chmod +x /usr/local/bin/buf \
     && buf --version
+
+# ── protoc-gen-connect-openapi (Go plugin for buf gen) ───────────────────────
+# Generates OpenAPI 3 schemas from Connect-flavored protobuf services. Required
+# by brefwiz services that emit OpenAPI alongside Connect bindings (ADR-0085).
+# `go install` into a stable bindir; Go itself is already present (golang-go).
+ENV GOBIN=/usr/local/bin
+RUN go install \
+        "github.com/sudorandom/protoc-gen-connect-openapi@${PROTOC_GEN_CONNECT_OPENAPI_VERSION}" \
+    && protoc-gen-connect-openapi --version 2>&1 | head -1 || \
+       echo "protoc-gen-connect-openapi installed (version flag may vary)"
 
 # ── Labels ────────────────────────────────────────────────────────────────────
 LABEL org.opencontainers.image.title="ci-base" \


### PR DESCRIPTION
## Summary

Adds `protoc-gen-connect-openapi` to the ci-base image so buf gen invocations succeed in CI for repos that emit OpenAPI alongside Connect bindings.

## Why

brefwiz services that conform to ADR-0085 emit OpenAPI 3 schemas from Connect-flavored protobuf via the Go-based `protoc-gen-connect-openapi` plugin. Today the plugin isn't installed in the rust-ci image, causing every CI job that runs `buf gen` (or `make proto-gen`) to fail with:

```
plugin protoc-gen-connect-openapi: exec: "protoc-gen-connect-openapi": executable file not found in $PATH
```

`brefwiz-nats` PR #27 has three failing CI checks (`SDK Build (TypeScript)`, `Release Dry-run Validation`, `E2E Admin Keypair`) all blocked on this exact error. Several other repos hit the same gap silently because the plugin call sits inside a generated `make` target.

Per ADR-0098 (mandate local buf plugins), each repo's `buf.gen*.yaml` already declares the plugin as `local: protoc-gen-connect-openapi` — it just needs to be on `$PATH` in the CI runner.

## Change

- Add `PROTOC_GEN_CONNECT_OPENAPI_VERSION=v0.16.0` ARG (pinned, top of Dockerfile alongside other version pins)
- After the buf install block, `go install github.com/sudorandom/protoc-gen-connect-openapi@${PROTOC_GEN_CONNECT_OPENAPI_VERSION}` with `GOBIN=/usr/local/bin` so the binary is on PATH platform-wide

`golang-go` is already in the apt install line, so no toolchain prereq added.

## Test plan

- [ ] CI builds both linux/amd64 and linux/arm64 images cleanly
- [ ] After publish + tag, brefwiz-nats PR #27 CI re-runs cleanly (no more "executable file not found in $PATH")
- [ ] No other repos broken by the change (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
