### PR TITLE
fix(docker): add aarch64-linux-musl-gcc wrapper via zig cc

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -149,6 +149,15 @@ RUN ln -s /usr/bin/aarch64-linux-gnu-strip /usr/local/bin/aarch64-linux-musl-str
     && aarch64-linux-musl-strip --version \
     && x86_64-linux-musl-strip --version
 
+# ── aarch64-linux-musl-gcc wrapper ───────────────────────────────────────────
+# cargo-zigbuild uses zig cc for aarch64 musl builds, but plain `cargo check
+# --target aarch64-unknown-linux-musl` (e.g. publish-preflight) invokes CC
+# directly via cc-rs. Provide a named wrapper so cc-rs finds its compiler.
+RUN printf '#!/bin/sh\nexec zig cc -target aarch64-linux-musl "$@"\n' \
+      > /usr/local/bin/aarch64-linux-musl-gcc \
+    && chmod +x /usr/local/bin/aarch64-linux-musl-gcc \
+    && aarch64-linux-musl-gcc --version
+
 # ── nats-server ───────────────────────────────────────────────────────────────
 # NATS asset name uses linux-amd64 / linux-arm64.
 RUN ARCH=$(dpkg --print-architecture) \


### PR DESCRIPTION
## Summary

- `publish-preflight` runs `cargo check --target aarch64-unknown-linux-musl`, which invokes `aarch64-linux-musl-gcc` via cc-rs for crates with C build scripts (e.g. `zstd-sys`)
- The image has zig installed (used by cargo-zigbuild) but no named wrapper binary
- Adds `/usr/local/bin/aarch64-linux-musl-gcc` → `zig cc -target aarch64-linux-musl`

## Test plan

- [ ] `aarch64-linux-musl-gcc --version` succeeds in the new image
- [ ] `cargo check --workspace --target aarch64-unknown-linux-musl` passes in publish-preflight CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)