### PR TITLE
fix(docker): strip --target= Rust triple from aarch64-linux-musl-gcc wrapper

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -153,7 +153,9 @@ RUN ln -s /usr/bin/aarch64-linux-gnu-strip /usr/local/bin/aarch64-linux-musl-str
 # cargo-zigbuild uses zig cc for aarch64 musl builds, but plain `cargo check
 # --target aarch64-unknown-linux-musl` (e.g. publish-preflight) invokes CC
 # directly via cc-rs. Provide a named wrapper so cc-rs finds its compiler.
-RUN printf '#!/bin/sh\nexec zig cc -target aarch64-linux-musl "$@"\n' \
+# cc-rs also passes --target=aarch64-unknown-linux-musl (Rust triple, not zig
+# syntax); strip it — the target is already hardcoded in this wrapper.
+RUN printf '#!/bin/bash\nargs=()\nfor a in "$@"; do [[ "$a" == --target=* ]] || args+=("$a"); done\nexec zig cc -target aarch64-linux-musl "${args[@]}"\n' \
       > /usr/local/bin/aarch64-linux-musl-gcc \
     && chmod +x /usr/local/bin/aarch64-linux-musl-gcc \
     && aarch64-linux-musl-gcc --version


### PR DESCRIPTION
## Summary
- cc-rs passes `--target=aarch64-unknown-linux-musl` (Rust triple format) when invoking the C compiler
- Zig doesn't recognize `unknown` as a valid OS, erroring with `UnknownOperatingSystem`  
- Fix: wrapper now strips any `--target=...` arg; the zig target is hardcoded in the wrapper itself

Fixes publish-preflight `cargo check --target aarch64-unknown-linux-musl` failures in zstd-sys build script.

## Test plan
- [ ] `build-images.yml` completes successfully  
- [ ] `publish-preflight` job on repo-template passes after image update

🤖 Generated with [Claude Code](https://claude.com/claude-code)