### PR TITLE
fix(docker): wire aarch64-musl cross-compile env for aws-lc-sys

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -112,7 +112,11 @@ ENV CARGO_TERM_COLOR=always \
     SCCACHE_DIR=/var/cache/sccache \
     SCCACHE_CACHE_SIZE=30G \
     SCCACHE_IDLE_TIMEOUT=0 \
-    RUSTUP_TOOLCHAIN=1.94.1
+    RUSTUP_TOOLCHAIN=1.94.1 \
+    AR_aarch64_unknown_linux_musl=llvm-ar \
+    AWS_LC_SYS_NO_ASM=1 \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
 
 # ── Ensure world-writable cargo/rustup (for non-root CI runners) ──────────────
 RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
## Summary

- Add 4 cross-compile env vars to `docker/ci.Dockerfile` ENV block to fix `aws-lc-sys` build script failure on `aarch64-unknown-linux-musl`
- `CC_aarch64_unknown_linux_musl` and `AR_aarch64_unknown_linux_musl` wire cc-rs to the existing zig-based musl wrapper
- `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` ensures the linker is correct for the target
- `AWS_LC_SYS_NO_ASM=1` disables asm that CMake cannot configure when cross-compiling (correctness-safe, perf-only tradeoff)

`CMAKE_SYSTEM_NAME` / `CMAKE_SYSTEM_PROCESSOR` deliberately omitted — would poison all CMake builds globally.

Closes #32

## Test plan

- [ ] CI image build completes without error
- [ ] `cargo build --target aarch64-unknown-linux-musl` no longer emits `UnknownOperatingSystem` from `aws-lc-sys`
- [ ] brefwiz-nats#27 `Build binary (arm64)` passes after image rebuild

## Local gates

- No SPEC.md in this repo — no spec-check target
