### PR TITLE
feat(ci-base): install cmake (required by aws-lc-sys build)

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -54,8 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     musl-tools gcc-aarch64-linux-gnu \
     # Protobuf compiler + well-known .proto files (prost-wkt-types needs them)
     protobuf-compiler libprotobuf-dev \
-    # Tools
-    ca-certificates curl git make jq tar xz-utils \
+    # Tools — cmake required by aws-lc-sys (rustls-aws-lc backend) at build time
+    ca-certificates curl git make cmake jq tar xz-utils \
     # Python + CI script deps (check-spec.py requires pyyaml + jsonschema)
     python3 python3-pip python3-venv python3-yaml python3-jsonschema \
     # Java 21 (openapi-generator-cli)


### PR DESCRIPTION
## Summary

Adds `cmake` to the ci-base image's apt install line. Required by `aws-lc-sys` 0.41+ at build time.

## Why

`aws-lc-sys` is pulled in transitively via `rustls-native-certs` → `async-nats` 0.48 (and any service using rustls with the aws-lc backend). Its `build.rs` invokes cmake unconditionally; without cmake on PATH it panics:

```
thread 'main' panicked at aws-lc-sys-0.41.0/builder/main.rs:566:38:
called `Result::unwrap()` on an `Err` value: "Required build dependency is missing. Halting build."
Missing dependency: cmake
```

Hit on brefwiz-nats#27 across **every** Rust job (Tests, Clippy, Coverage, Build, Publish Preflight). Not arch-specific — affects both amd64 and arm64.

## Test plan

- [ ] CI builds the image cleanly
- [ ] brefwiz-nats#27 re-run completes the Rust pipeline (aws-lc-sys builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)