### PR TITLE
fix(ci): drop AWS_LC_SYS_NO_ASM — incompatible with release builds

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -114,7 +114,6 @@ ENV CARGO_TERM_COLOR=always \
     SCCACHE_IDLE_TIMEOUT=0 \
     RUSTUP_TOOLCHAIN=1.94.1 \
     AR_aarch64_unknown_linux_musl=llvm-ar \
-    AWS_LC_SYS_NO_ASM=1 \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
     CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
 


### PR DESCRIPTION
## Summary

Drops `AWS_LC_SYS_NO_ASM=1` from the CI image's global env. It panics on every release build:

```
thread 'main' panicked at aws-lc-sys-0.41.0/builder/cmake_builder.rs:188:17:
AWS_LC_SYS_NO_ASM only allowed for debug builds!
```

## Why

Added in #33 as a workaround when cmake wasn't installed in the image. With #34 (cmake landed), the cmake builder path works for both debug and release on amd64 + aarch64-musl. `AWS_LC_SYS_NO_ASM` is now unnecessary and actively breaking the binary-build job on every consumer repo.

Hit on brefwiz-nats#27 `Build binary (amd64)` and `Build binary (arm64)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
