### PR TITLE
fix(ci): strip -march=* in aarch64-linux-musl-gcc wrapper

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -155,7 +155,10 @@ RUN ln -s /usr/bin/aarch64-linux-gnu-strip /usr/local/bin/aarch64-linux-musl-str
 # directly via cc-rs. Provide a named wrapper so cc-rs finds its compiler.
 # cc-rs also passes --target=aarch64-unknown-linux-musl (Rust triple, not zig
 # syntax); strip it — the target is already hardcoded in this wrapper.
-RUN printf '#!/bin/bash\nargs=()\nfor a in "$@"; do [[ "$a" == --target=* ]] || args+=("$a"); done\nexec zig cc -target aarch64-linux-musl "${args[@]}"\n' \
+# -march=* flags from crate build scripts (ring, aws-lc-sys, zstd-sys) use GCC
+# arch names (e.g. armv8.4-a) that Zig's CC frontend does not recognise. Strip
+# them: the target triple already encodes the architecture for Zig.
+RUN printf '#!/bin/bash\nargs=()\nfor a in "$@"; do\n  [[ "$a" == --target=* ]] && continue\n  [[ "$a" == -march=* ]]   && continue\n  args+=("$a")\ndone\nexec zig cc -target aarch64-linux-musl "${args[@]}"\n' \
       > /usr/local/bin/aarch64-linux-musl-gcc \
     && chmod +x /usr/local/bin/aarch64-linux-musl-gcc \
     && aarch64-linux-musl-gcc --version


### PR DESCRIPTION
## Problem

The `aarch64-linux-musl-gcc` wrapper in `ci-base.Dockerfile` already strips `--target=*` args (Rust triple syntax, incompatible with Zig). It did not strip `-march=*` flags.

Crates with C build scripts — `ring`, `aws-lc-sys`, `zstd-sys` — pass GCC arch names like `-march=armv8.4-a` via cc-rs. Zig's CC frontend uses different CPU naming and rejects these with:

```
error: unknown CPU: 'armv8.4'
```

This broke the `Build sealwiz-service binary (arm64)` job in every repo after the runner image re-release (brefwiz/sealwiz#326 is the immediate caller).

## Fix

Strip `-march=*` in the same loop that strips `--target=*`. The architecture is already encoded in `-target aarch64-linux-musl` passed to Zig, so the GCC `-march` flag is both redundant and incompatible.

## Test

Rebuild the CI image and verify `cargo zigbuild --target aarch64-unknown-linux-musl` compiles `ring`, `aws-lc-sys`, and `zstd-sys` without error.