### PR TITLE
fix(ci-base): add llvm-ar wrapper via zig ar for aarch64-musl builds

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -160,6 +160,16 @@ RUN printf '#!/bin/bash\nargs=()\nfor a in "$@"; do [[ "$a" == --target=* ]] || 
     && chmod +x /usr/local/bin/aarch64-linux-musl-gcc \
     && aarch64-linux-musl-gcc --version
 
+# ── llvm-ar wrapper ───────────────────────────────────────────────────────────
+# ci.Dockerfile sets AR_aarch64_unknown_linux_musl=llvm-ar so cc-rs uses the
+# right archiver for aarch64-musl builds (ring, aws-lc-sys, zstd-sys). zig ar
+# provides a fully compatible ar implementation; expose it as llvm-ar so the
+# env var resolves without requiring the full llvm package.
+RUN printf '#!/bin/sh\nexec zig ar "$@"\n' \
+      > /usr/local/bin/llvm-ar \
+    && chmod +x /usr/local/bin/llvm-ar \
+    && llvm-ar --version
+
 # ── nats-server ───────────────────────────────────────────────────────────────
 # NATS asset name uses linux-amd64 / linux-arm64.
 RUN ARCH=$(dpkg --print-architecture) \


### PR DESCRIPTION
## Summary

- Add `llvm-ar` wrapper (`zig ar`) in `ci-base.Dockerfile` — fixes arm64 binary build failures
- Complements the existing `aarch64-linux-musl-gcc` → `zig cc` wrapper pattern

## Root cause

`ci.Dockerfile` sets `AR_aarch64_unknown_linux_musl=llvm-ar` so cc-rs uses the right archiver when building C deps (`ring`, `aws-lc-sys`, `zstd-sys`) for `aarch64-unknown-linux-musl`. `llvm-ar` was never installed, causing build-script failures:

```
error occurred in cc-rs: failed to find tool "llvm-ar": No such file or directory
```

## Fix

Add `/usr/local/bin/llvm-ar` as a thin wrapper: `exec zig ar "$@"`. Zig provides a fully compatible ar implementation and is already installed for the `aarch64-linux-musl-gcc` wrapper.

## Test plan

- [ ] Rebuild CI image (`build-images.yml`)
- [ ] brefwiz-spiffe `CI / Build binary (arm64)` passes
