### PR TITLE
fix(ci): disable rustc self-contained crt for aarch64-musl release link

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -115,7 +115,12 @@ ENV CARGO_TERM_COLOR=always \
     RUSTUP_TOOLCHAIN=1.94.1 \
     AR_aarch64_unknown_linux_musl=llvm-ar \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    # zig cc (our musl-gcc wrapper) provides its own crt1.o; rustc's
+    # self-contained crt also ships crt1.o for aarch64-unknown-linux-musl,
+    # causing duplicate `_start` at link time. Tell rustc to skip its
+    # self-contained linker components for this target — zig owns crt.
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-self-contained=no"
 
 # ── Ensure world-writable cargo/rustup (for non-root CI runners) ──────────────
 RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
## Summary

Disables rustc's self-contained crt for `aarch64-unknown-linux-musl` so it doesn't conflict with zig cc's crt1.o.

Closes #38.

## Why

`aarch64-linux-musl-gcc` in this image is a zig-cc wrapper (`ci-base.Dockerfile` lines 156-161). zig ships its own `crt1.o` when used as a linker. rustc's `aarch64-unknown-linux-musl` target also ships a self-contained `crt1.o` in its sysroot. Both get linked → duplicate `_start` / `_start_c` at link time:

```
ld.lld: error: duplicate symbol: _start
>>> defined at crt1.c
>>>            /root/.cache/zig/.../crt1.o
>>> defined at crt1.c
>>>            /usr/local/rustup/.../aarch64-unknown-linux-musl/lib/self-contained/crt1.o
```

Was masked previously by `aws-lc-sys` failing earlier in the pipeline (#33-#35 cleared those); the link step is now reachable.

## Fix

```dockerfile
CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-self-contained=no"
```

Tells rustc to skip its self-contained crt for the aarch64-musl target. zig owns crt for that target; rustc just produces objects. x86_64-musl unaffected (uses real musl-gcc, no zig wrapper, no conflict).

## Test plan

- [ ] CI image builds cleanly
- [ ] brefwiz-nats#27 `Build binary (arm64)` link step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
