### PR TITLE
fix(ci): disable rustc self-contained crt for aarch64-musl release link

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Protobuf compiler + well-known .proto files (prost-wkt-types needs them)
     protobuf-compiler libprotobuf-dev \
     # Tools — cmake required by aws-lc-sys (rustls-aws-lc backend) at build time
-    ca-certificates curl git make cmake jq tar xz-utils \
+    ca-certificates curl git make cmake jq tar xz-utils openssh-client \
     # Python + CI script deps (check-spec.py requires pyyaml + jsonschema)
     python3 python3-pip python3-venv python3-yaml python3-jsonschema \
     # Java 21 (openapi-generator-cli)

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -115,7 +115,12 @@ ENV CARGO_TERM_COLOR=always \
     RUSTUP_TOOLCHAIN=1.94.1 \
     AR_aarch64_unknown_linux_musl=llvm-ar \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    # zig cc (our musl-gcc wrapper) provides its own crt1.o; rustc's
+    # self-contained crt also ships crt1.o for aarch64-unknown-linux-musl,
+    # causing duplicate `_start` at link time. Tell rustc to skip its
+    # self-contained linker components for this target — zig owns crt.
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-self-contained=no"
 
 # ── Ensure world-writable cargo/rustup (for non-root CI runners) ──────────────
 RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
## Summary

- Sets `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-self-contained=no"` in `ci.Dockerfile`
- zig cc (our `aarch64-linux-musl-gcc` wrapper) provides its own `crt1.o`; rustc's `aarch64-unknown-linux-musl` self-contained sysroot also ships `crt1.o`, producing duplicate `_start` / `_start_c` at link time
- `link-self-contained=no` tells rustc to skip its own crt objects — zig owns crt

## Context

Unblocks brefwiz/sealwiz#326. The `-march=*` fix (#36) cleared C-compilation failures; the link step is now reachable and hits this duplicate-symbol error.

## Test plan

- [ ] Image build workflow passes on both amd64 and arm64
- [ ] `sealwiz-service` arm64 binary build passes after image update

🤖 Generated with [Claude Code](https://claude.com/claude-code)