### PR TITLE
fix(ci): install openssh-client and docker-compose-plugin in ci-base image

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Protobuf compiler + well-known .proto files (prost-wkt-types needs them)
     protobuf-compiler libprotobuf-dev \
     # Tools — cmake required by aws-lc-sys (rustls-aws-lc backend) at build time
-    ca-certificates curl git make cmake jq tar xz-utils \
+    ca-certificates curl git make cmake jq tar xz-utils openssh-client \
     # Python + CI script deps (check-spec.py requires pyyaml + jsonschema)
     python3 python3-pip python3-venv python3-yaml python3-jsonschema \
     # Java 21 (openapi-generator-cli)

--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -134,10 +134,11 @@ RUN install -m 0755 -d /etc/apt/keyrings \
         > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        docker-ce-cli docker-buildx-plugin \
+        docker-ce-cli docker-buildx-plugin docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/* \
     && docker --version \
-    && docker buildx version
+    && docker buildx version \
+    && docker compose version
 
 # ── musl strip aliases ────────────────────────────────────────────────────────
 # aarch64-linux-gnu-strip (from gcc-aarch64-linux-gnu) strips musl ELF identically

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -115,7 +115,12 @@ ENV CARGO_TERM_COLOR=always \
     RUSTUP_TOOLCHAIN=1.94.1 \
     AR_aarch64_unknown_linux_musl=llvm-ar \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
-    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc
+    CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    # zig cc (our musl-gcc wrapper) provides its own crt1.o; rustc's
+    # self-contained crt also ships crt1.o for aarch64-unknown-linux-musl,
+    # causing duplicate `_start` at link time. Tell rustc to skip its
+    # self-contained linker components for this target — zig owns crt.
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-self-contained=no"
 
 # ── Ensure world-writable cargo/rustup (for non-root CI runners) ──────────────
 RUN chmod -R a+rwX /usr/local/cargo /usr/local/rustup


### PR DESCRIPTION
## Summary
- Add `openssh-client` to the `ci-base` image apt install block

## Test plan
- [ ] CI image builds without error
- [ ] `ssh` binary available in CI containers
