### PR TITLE
fix(ci-base): add python3-pydantic to apt layer

### DIFF
--- a/docker/ci-base.Dockerfile
+++ b/docker/ci-base.Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Tools — cmake required by aws-lc-sys (rustls-aws-lc backend) at build time
     ca-certificates curl git make cmake jq rsync tar xz-utils zstd openssh-client \
     # Python + CI script deps (check-spec.py requires pyyaml + jsonschema)
-    python3 python3-pip python3-venv python3-yaml python3-jsonschema \
+    python3 python3-pip python3-venv python3-yaml python3-jsonschema python3-pydantic \
     # Java 21 (openapi-generator-cli)
     openjdk-21-jdk-headless \
     # Go (SDK generation utilities)


### PR DESCRIPTION
## Summary

- Adds `python3-pydantic` to the apt install layer in `ci-base.Dockerfile`
- Avoids pip entirely — uses the Debian trixie package, consistent with `python3-yaml` and `python3-jsonschema` already present
- No extra layer, no `--break-system-packages` workaround needed

## Test plan

- [ ] CI image builds successfully
- [ ] `python3 -c "import pydantic"` passes in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)