### PR TITLE
feat(ci-image): add cargo-sweep 0.8.0 for rust-cache snapshot pruning

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -26,6 +26,7 @@ ARG CARGO_DENY_VERSION=0.19.4
 ARG CARGO_HACK_VERSION=0.6.37
 ARG SCCACHE_VERSION=0.10.0
 ARG CARGO_ZIGBUILD_VERSION=0.19.4
+ARG CARGO_SWEEP_VERSION=0.8.0
 ARG CARGO_VULN_POLICY_VALIDATOR_REPO=https://github.com/brefwiz/cargo-vuln-policy-validator
 ARG CARGO_VULN_POLICY_VALIDATOR_REF=main
 ARG CI_BASE_TAG=latest
@@ -86,6 +87,7 @@ RUN cargo binstall --no-confirm --locked \
         cargo-deny@${CARGO_DENY_VERSION} \
         sccache@${SCCACHE_VERSION} \
         cargo-zigbuild@${CARGO_ZIGBUILD_VERSION} \
+        cargo-sweep@${CARGO_SWEEP_VERSION} \
         sqlx-cli@${SQLX_CLI_VERSION} \
     && cargo nextest --version \
     && cargo llvm-cov --version \
@@ -95,6 +97,7 @@ RUN cargo binstall --no-confirm --locked \
     && cargo deny --version \
     && sccache --version \
     && cargo zigbuild --help > /dev/null \
+    && cargo sweep --version \
     && sqlx --version
 
 # ── Private cargo tools (must compile from source) ────────────────────────────


### PR DESCRIPTION
Adds `cargo-sweep` to the binstall tool block in `docker/ci.Dockerfile`.

Consumed by the `rust-cache-restore` / `rust-cache-save` composites (brefwiz/ci-workflows#553): restore stamps after extract, save sweeps before pack — snapshots converge to the build's working set instead of growing monotonically down the `latest`-pointer chain until the size guard blocks uploads.

Composites guard on `command -v cargo-sweep` so images lagging this change degrade to unpruned snapshots with a warning, not failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)