### PR TITLE
fix(policy): allowlist RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/policies/audit.toml
+++ b/policies/audit.toml
@@ -25,4 +25,9 @@ ignore = [
     # Remove once sqlx upgrades to rand 0.9.
     # review-by: 2026-07-20
     "RUSTSEC-2026-0097",
+    # proc-macro-error2 unmaintained, transitive via validator_derive (validator 0.20,
+    # latest) which api-bones and others pull. Not a vulnerability; no upstream fix until
+    # validator migrates off it. Tracks brefwiz/socle#90.
+    # review-by: 2026-09-20
+    "RUSTSEC-2026-0173",
 ]

--- a/policies/deny.toml
+++ b/policies/deny.toml
@@ -54,4 +54,6 @@ ignore = [
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin via sqlx-mysql lockfile; postgres-only feature set at runtime" },
     # review-by: 2026-07-20
     { id = "RUSTSEC-2026-0097", reason = "rand unsound aliased-mut-ref via sqlx-postgres 0.8.x; fix requires rand >= 0.9.3 not yet released by sqlx 0.8.x; UB conditions extremely narrow (custom logger + trace + ThreadRng reseed)" },
+    # review-by: 2026-09-20
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive via validator_derive (validator 0.20, latest release) which api-bones and others pull; not a vulnerability; no upstream fix until validator migrates off it. Tracks brefwiz/socle#90" },
 ]


### PR DESCRIPTION
## Allowlist RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

`proc-macro-error2` was confirmed unmaintained (RUSTSEC-2026-0173). It enters the tree transitively via `validator_derive` (validator 0.20, the latest release), which `api-bones` and others pull — so the `Security (audit + deny)` job now fails platform-wide for every validator/api-bones consumer (socle, service-kit, sealwiz, quorumauth, …).

Not a vulnerability (unmaintained advisory); no upstream fix until `validator` migrates off proc-macro-error2, and several crates use `validator::Validate` directly so it can't be dropped. Added to both `deny.toml` and `audit.toml` with a `review-by` 90-day expiry, matching the existing transitive-no-fix entries.

Tracks brefwiz/socle#90.
